### PR TITLE
Add UIZZE to UI & UX resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ See [`contributing.md`](https://github.com/shsfwork/awesome-inspiration/blob/mai
 
 - [Collect UI](https://collectui.com/) - Daily inspiration collected from daily ui archive and beyond. Based on Dribbble shots, hand picked, updating daily.
 - [Pageflows](https://pageflows.com/) - Explore real-world user flows and design patterns from leading apps and websites.
+- [UIZZE](https://uizze.com) - Search 800,000+ real web and iOS screens to give Codex, Claude Code, Cursor, and product teams specific UI direction instead of generic UI slop.
 
 ## Onboarding
 


### PR DESCRIPTION
## What changed

- Added UIZZE to the UI & UX resources section.
- Linked directly to the product homepage with a factual description of its searchable web/iOS reference catalogue and coding-agent use case.

## Why

UIZZE is a relevant UI inspiration resource for designers, developers, and people using Codex, Claude Code, or Cursor to build interfaces.

## Validation

- Confirmed `https://uizze.com` returns HTTP 200.
- Ran `git diff --check`.
