### PR TITLE
Add Nutilz Color Picker to Color section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ See [`contributing.md`](https://github.com/shsfwork/awesome-inspiration/blob/mai
 ## Color
 
 - [Looka](https://looka.com/blog/color-combinations/) - 60 Stunning Color Combinations to Elevate Your Next Project
+- [Nutilz Color Picker](https://nutilz.com/color-picker) - Free browser-based color picker that converts HEX, RGB, and HSL instantly, generates a five-color complementary palette, and outputs a ready-to-paste CSS variable. No upload, no signup.
 
 ## Newsletter
 


### PR DESCRIPTION
Adds Nutilz Color Picker (https://nutilz.com/color-picker) to the Color section.

What it does: a free, browser-based color picker. Pick a color visually (native color wheel or direct HEX input) and instantly get HEX, RGB, and HSL values, plus a ready-to-paste CSS custom property (`--color-primary: ...`). It also generates a five-color complementary palette from the chosen color for quick harmony exploration.

Fully client-side, no upload, no signup, no ads gating the core tool. Part of Nutilz, a free online tools site.