### PR TITLE
Refresh UIZZE UI/UX resource entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [`contributing.md`](https://github.com/shsfwork/awesome-inspiration/blob/mai
 
 - [Collect UI](https://collectui.com/) - Daily inspiration collected from daily ui archive and beyond. Based on Dribbble shots, hand picked, updating daily.
 - [Pageflows](https://pageflows.com/) - Explore real-world user flows and design patterns from leading apps and websites.
-- [UIZZE](https://uizze.com) - Search 800,000+ real web and iOS screens to give Codex, Claude Code, Cursor, and product teams specific UI direction instead of generic UI slop.
+- [UIZZE](https://uizze.com) - Free MIT anti-ui-slop Skill with a product-specific design contract, required UI states, and hard finish gate; full UIZZE adds live search, validation, and audits across 800,000+ real web and iOS screens.
 
 ## Onboarding
 


### PR DESCRIPTION
## What changed

Refreshes the existing UIZZE entry in the UI & UX section with current, source-backed copy:

- free MIT anti-ui-slop Skill
- product-specific design contract, required UI states, and hard finish gate
- full UIZZE live search, validation, and audits across 800,000+ real web and iOS screens

This is a one-line maintenance update; no other resources changed. I build UIZZE and am disclosing the first-party relationship.

## Checks

- `git diff --check`
- canonical homepage and repository verified