### PR TITLE
Add ArtboardLab to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ See [`contributing.md`](https://github.com/shsfwork/awesome-inspiration/blob/mai
 - [BulkPicTools](https://bulkpictools.com/) - Free browser-based bulk image processor. Compress, convert (HEIC/WebP/AVIF/PNG/JPG), resize, crop, watermark 1,000+ images at once — no upload, no account needed.
 - [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based utility suite: favicon generator, OG image generator, color palette generator, AI background remover (runs locally, no upload), domain name generator, SEO meta tag generator, AI cost calculator, AI content disclosure generator, and AI robots.txt generator. Open source.
 - [igly.ai](https://igly.ai) - AI image editing platform for background removal, inpainting, upscaling, and generative fill.
-- [ArtboardLab](https://artboardlab.com) - Free browser-based design tools: open, view, and convert Adobe Illustrator (.ai) files to SVG/PNG/PDF, plus image compression (PNG/JPG/WebP/AVIF). Runs entirely in-browser via WASM — no upload, no account needed.
+- [ArtboardLab](https://artboardlab.com) - Free browser-based design tools: open and convert Adobe Illustrator (.ai) files to SVG/PNG/PDF, plus image compression (PNG/JPG/WebP/AVIF). Everything runs in the browser — no upload, no account needed.
 
 ## Interface
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ See [`contributing.md`](https://github.com/shsfwork/awesome-inspiration/blob/mai
 - [BulkPicTools](https://bulkpictools.com/) - Free browser-based bulk image processor. Compress, convert (HEIC/WebP/AVIF/PNG/JPG), resize, crop, watermark 1,000+ images at once — no upload, no account needed.
 - [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based utility suite: favicon generator, OG image generator, color palette generator, AI background remover (runs locally, no upload), domain name generator, SEO meta tag generator, AI cost calculator, AI content disclosure generator, and AI robots.txt generator. Open source.
 - [igly.ai](https://igly.ai) - AI image editing platform for background removal, inpainting, upscaling, and generative fill.
+- [ArtboardLab](https://artboardlab.com) - Free browser-based design tools: open, view, and convert Adobe Illustrator (.ai) files to SVG/PNG/PDF, plus image compression (PNG/JPG/WebP/AVIF). Runs entirely in-browser via WASM — no upload, no account needed.
 
 ## Interface
 


### PR DESCRIPTION
Adding ArtboardLab to the Development section.

**Disclosure: I built this.** I'm the maker of ArtboardLab (https://artboardlab.com).

What it is: a free browser-based tool site for designers. Everything runs client-side (WASM) — no file upload, no account. Two things it does:
- Opens/views Adobe Illustrator `.ai` files and converts them to SVG/PNG/PDF in-browser.
- Image compression/format conversion (PNG/JPG/WebP/AVIF).

Why Development: it's a dev/design utility, in line with existing entries in that section (BulkPicTools, TinyTools) which are also free, no-upload, browser-based tool suites.

Checked for duplicates before submitting: `grep -in "illustrator\|artboard\|\.ai " README.md` returned no matches, so there's no existing entry to conflict with.

Diff is a single added line, matching the existing entry format/style.
