### PR TITLE
Add Kombai Gallery to UI & UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See [`contributing.md`](https://github.com/shsfwork/awesome-inspiration/blob/mai
 - [Collect UI](https://collectui.com/) - Daily inspiration collected from daily ui archive and beyond. Based on Dribbble shots, hand picked, updating daily.
 - [Pageflows](https://pageflows.com/) - Explore real-world user flows and design patterns from leading apps and websites.
 - [UIZZE](https://uizze.com) - Search 800,000+ real web and iOS screens to give Codex, Claude Code, Cursor, and product teams specific UI direction instead of generic UI slop.
+- [Kombai Gallery](https://kombai.com/gallery/web/) - A free, growing library of web and mobile UI inspiration for designers and design engineers to explore, adapt, and remix into real products.
 
 ## Onboarding
 


### PR DESCRIPTION
Adds [Kombai Gallery](https://kombai.com/gallery/web/) to the UI & UX section, alongside Pageflows and UIZZE.

Kombai Gallery is a free, growing library of web and mobile UI inspiration for designers and design engineers to explore, adapt, and remix into real products.